### PR TITLE
More work on porting to Godot4 -- Part 2

### DIFF
--- a/addons/rmsmartshape/plugin.gd
+++ b/addons/rmsmartshape/plugin.gd
@@ -120,6 +120,7 @@ var tb_edge_edit: Button = null
 var tb_pivot: Button = null
 var tb_collision: Button = null
 var tb_freehand: Button = null
+var tb_button_group: ButtonGroup = null
 
 var tb_snap: MenuButton = null
 # The PopupMenu that belongs to tb_snap
@@ -198,6 +199,8 @@ func _gui_build_toolbar():
 	var sep = VSeparator.new()
 	tb_hb.add_child(sep)
 
+	tb_button_group = ButtonGroup.new()
+
 	tb_vert_create = create_tool_button(ICON_CURVE_CREATE, SS2D_Strings.EN_TOOLTIP_CREATE_VERT)
 	tb_vert_create.connect("pressed",Callable(self,"_enter_mode").bind(MODE.CREATE_VERT))
 	tb_vert_create.button_pressed = true
@@ -234,9 +237,12 @@ func _gui_build_toolbar():
 	tb_hb_legacy_import.hide()
 
 
-func create_tool_button(icon, tooltip):
-	var tb = Button.new()
+func create_tool_button(icon: Texture2D, tooltip: String) -> Button:
+	var tb := Button.new()
 	tb.toggle_mode = true
+	tb.button_group =  tb_button_group
+	tb.focus_mode = Control.FOCUS_NONE
+	tb.flat = true
 	tb.icon = icon
 	tb.tooltip_text = tooltip
 	tb_hb.add_child(tb)

--- a/addons/rmsmartshape/scenes/GUI_Edge_InfoPanel.gd
+++ b/addons/rmsmartshape/scenes/GUI_Edge_InfoPanel.gd
@@ -1,67 +1,60 @@
 @tool
 extends PanelContainer
 
-@export (NodePath) var p_lbl_idx
-@export (NodePath) var p_btn_material_override
-@export (NodePath) var p_ctr_override
-@export (NodePath) var p_chk_render
-@export (NodePath) var p_chk_weld
-@export (NodePath) var p_int_index
-@export (NodePath) var p_btn_edge_material
-@export (NodePath) var p_btn_clear_edge_material
-@export (NodePath) var p_lbl_edge_material
 
-var indicies = [-1, -1] : set = set_indicies
-var edge_material = null
-var edge_material_selector = FileDialog.new()
+signal material_override_toggled(enabled)
+signal render_toggled(enabled)
+signal weld_toggled(enabled)
+signal z_index_changed(value)
+signal edge_material_changed(value)
 
-signal set_material_override(enabled)
-signal set_render(enabled)
-signal set_weld(enabled)
-signal set_z_index(value)
-signal set_edge_material(value)
+var indicies: Array[int] = [-1, -1] : set = set_indicies
+var edge_material: SS2D_Material_Edge = null
+var edge_material_selector := FileDialog.new()
+
+@onready var idx_label: Label = %IDX
+@onready var material_override_button: Button = %MaterialOverride
+@onready var override_container: Container = %OverrideContainer
+@onready var render_checkbox: CheckBox = %Render
+@onready var weld_checkbox: CheckBox = %Weld
+@onready var z_index_spinbox: SpinBox = %ZIndex
+@onready var set_material_button: Button = %SetMaterial
+@onready var clear_material_button: Button = %ClearMaterial
+@onready var material_status: Label = %MaterialStatus
 
 
-func _ready():
-	var n_btn_override = get_node(p_btn_material_override)
-	n_btn_override.connect("toggled",Callable(self,"_on_toggle_material_override"))
+func _ready() -> void:
+	material_override_button.connect("toggled", Callable(self, "_on_toggle_material_override"))
+	render_checkbox.connect("toggled", Callable(self, "_on_toggle_render"))
+	weld_checkbox.connect("toggled", Callable(self, "_on_toggle_weld"))
+	z_index_spinbox.connect("value_changed", Callable(self, "_on_set_z_index"))
+	set_material_button.connect("pressed", Callable(self, "_on_set_edge_material_pressed"))
+	clear_material_button.connect("pressed", Callable(self, "_on_set_edge_material_clear_pressed"))
 
-	var n_chk_render = get_node(p_chk_render)
-	n_chk_render.connect("toggled",Callable(self,"_on_toggle_render"))
+	override_container.hide()
+	clear_material_button.hide()
 
-	var n_btn_weld = get_node(p_chk_weld)
-	n_btn_weld.connect("toggled",Callable(self,"_on_toggle_weld"))
-
-	var n_int_index = get_node(p_int_index)
-	n_int_index.connect("value_changed",Callable(self,"_on_set_z_index"))
-
-	var n_btn_edge_material = get_node(p_btn_edge_material)
-	n_btn_edge_material.connect("pressed",Callable(self,"_on_set_edge_material_pressed"))
-
-	var n_btn_clear_edge_material = get_node(p_btn_clear_edge_material)
-	n_btn_clear_edge_material.connect("pressed",Callable(self,"_on_set_edge_material_clear_pressed"))
-
-	edge_material_selector.mode = FileDialog.FILE_MODE_OPEN_FILE
+	edge_material_selector.file_mode = FileDialog.FILE_MODE_OPEN_FILE
 	edge_material_selector.dialog_hide_on_ok = true
 	edge_material_selector.show_hidden_files = true
 	edge_material_selector.mode_overrides_title = false
-	edge_material_selector.window_title = "Select Edge Material"
+	edge_material_selector.title = "Select Edge Material"
 	edge_material_selector.filters = PackedStringArray(["*.tres"])
 	edge_material_selector.connect("file_selected",Callable(self,"_on_set_edge_material_file_selected"))
 	add_child(edge_material_selector)
 
 
-func _on_set_edge_material_clear_pressed():
+func _on_set_edge_material_clear_pressed() -> void:
 	set_edge_material(null)
 
 
-func _on_set_edge_material_pressed():
+func _on_set_edge_material_pressed() -> void:
 	# Update file list
 	edge_material_selector.invalidate()
 	edge_material_selector.popup_centered_ratio(0.8)
 
 
-func _on_set_edge_material_file_selected(f: String):
+func _on_set_edge_material_file_selected(f: String) -> void:
 	var rsc = load(f)
 	if not rsc is SS2D_Material_Edge:
 		push_error("Selected resource is not an Edge Material! (SS2D_Material_Edge)")
@@ -69,86 +62,84 @@ func _on_set_edge_material_file_selected(f: String):
 	set_edge_material(rsc)
 
 
-func set_indicies(a: Array):
+func set_indicies(a: Array[int]) -> void:
 	indicies = a
-	get_node(p_lbl_idx).text = "IDX: [%s, %s]" % [indicies[0], indicies[1]]
+	idx_label.text = "IDX: [%s, %s]" % [indicies[0], indicies[1]]
 
 
-func set_material_override(enabled: bool):
-	var n_btn_override = get_node(p_btn_material_override)
-	n_btn_override.button_pressed = enabled
+func set_material_override(enabled: bool) -> void:
+	material_override_button.button_pressed = enabled
 	_on_toggle_material_override(enabled)
 
 
-func set_render(enabled: bool, emit: bool = true):
-	get_node(p_chk_render).button_pressed = enabled
+func set_render(enabled: bool, emit: bool = true) -> void:
+	render_checkbox.button_pressed = enabled
 	if emit:
 		_on_toggle_render(enabled)
 
 
-func set_weld(enabled: bool, emit: bool = true):
-	get_node(p_chk_weld).button_pressed = enabled
+func set_weld(enabled: bool, emit: bool = true) -> void:
+	weld_checkbox.button_pressed = enabled
 	if emit:
 		_on_toggle_weld(enabled)
 
 
-func set_edge_material(v: SS2D_Material_Edge, emit: bool = true):
+func set_edge_material(v: SS2D_Material_Edge, emit: bool = true) -> void:
 	edge_material = v
 	if v == null:
-		get_node(p_lbl_edge_material).text = "[No Material]"
-		get_node(p_btn_clear_edge_material).visible = false
+		material_status.text = "[No Material]"
+		clear_material_button.visible = false
 	else:
 		# Call string function 'get_file()' to get the filepath
-		get_node(p_lbl_edge_material).text = "[%s]" % (v.resource_path).get_file()
-		get_node(p_btn_clear_edge_material).visible = true
+		material_status.text = "[%s]" % (v.resource_path).get_file()
+		clear_material_button.visible = true
 	if emit:
-		emit_signal("set_edge_material", v)
+		emit_signal("edge_material_changed", v)
 
 
-func set_z_index(v: int, emit: bool = true):
-	get_node(p_int_index).value = float(v)
+func set_edge_z_index(v: int, emit: bool = true) -> void:
+	z_index_spinbox.value = float(v)
 	if emit:
 		_on_set_z_index(float(v))
 
 
 func get_render() -> bool:
-	return get_node(p_chk_render).pressed
+	return render_checkbox.button_pressed
 
 
 func get_weld() -> bool:
-	return get_node(p_chk_weld).pressed
+	return weld_checkbox.button_pressed
 
 
-func get_z_index() -> int:
-	return get_node(p_int_index).value
+func get_edge_z_index() -> int:
+	return int(z_index_spinbox.value)
 
 
-func _on_toggle_material_override(pressed: bool):
-	var n_override_container = get_node(p_ctr_override)
-	n_override_container.visible = pressed
-	emit_signal("set_material_override", pressed)
+func _on_toggle_material_override(pressed: bool) -> void:
+	override_container.visible = pressed
+	emit_signal("material_override_toggled", pressed)
 
 
-func _on_toggle_render(pressed: bool):
-	emit_signal("set_render", pressed)
+func _on_toggle_render(pressed: bool) -> void:
+	emit_signal("render_toggled", pressed)
 
 
-func _on_toggle_weld(pressed: bool):
-	emit_signal("set_weld", pressed)
+func _on_toggle_weld(pressed: bool) -> void:
+	emit_signal("weld_toggled", pressed)
 
 
-func _on_set_z_index(v: float):
-	emit_signal("set_z_index", int(v))
+func _on_set_z_index(v: float) -> void:
+	emit_signal("z_index_changed", int(v))
 
 
-func load_values_from_meta_material(meta_mat: SS2D_Material_Edge_Metadata):
+func load_values_from_meta_material(meta_mat: SS2D_Material_Edge_Metadata) -> void:
 	set_render(meta_mat.render)
 	set_weld(meta_mat.weld)
 	set_z_index(meta_mat.z_index)
 	set_edge_material(meta_mat.edge_material)
 
 
-func save_values_to_meta_material(meta_mat: SS2D_Material_Edge_Metadata):
+func save_values_to_meta_material(meta_mat: SS2D_Material_Edge_Metadata) -> void:
 	meta_mat.render = get_render()
 	meta_mat.weld = get_weld()
 	meta_mat.z_index = get_z_index()

--- a/addons/rmsmartshape/scenes/GUI_Edge_InfoPanel.tscn
+++ b/addons/rmsmartshape/scenes/GUI_Edge_InfoPanel.tscn
@@ -1,134 +1,100 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=3 format=3 uid="uid://cy1l6tyadc4s3"]
 
-[ext_resource path="res://addons/rmsmartshape/assets/GUI_Theme.tres" type="Theme" id=1]
-[ext_resource path="res://addons/rmsmartshape/scenes/GUI_Edge_InfoPanel.gd" type="Script" id=2]
+[ext_resource type="Theme" uid="uid://bdtg0tabufa3j" path="res://addons/rmsmartshape/assets/GUI_Theme.tres" id="1"]
+[ext_resource type="Script" path="res://addons/rmsmartshape/scenes/GUI_Edge_InfoPanel.gd" id="2"]
 
 [node name="GUI_Edge_InfoPanel" type="PanelContainer"]
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_right = -918.0
-offset_bottom = -486.0
-mouse_filter = 2
+anchors_preset = -1
+anchor_right = 0.203125
+anchor_bottom = 0.345679
+offset_bottom = -62.0
 size_flags_horizontal = 4
 size_flags_vertical = 4
-theme = ExtResource( 1 )
-script = ExtResource( 2 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-p_lbl_idx = NodePath("Container/Properties/IDX")
-p_btn_material_override = NodePath("Container/Functions/MaterialOverride")
-p_ctr_override = NodePath("Container/Override")
-p_chk_render = NodePath("Container/Override/Render")
-p_chk_weld = NodePath("Container/Override/Weld")
-p_int_index = NodePath("Container/Override/Z_Index/Z_index")
-p_btn_edge_material = NodePath("Container/Override/SetMaterial")
-p_btn_clear_edge_material = NodePath("Container/Override/ClearMaterial")
-p_lbl_edge_material = NodePath("Container/Override/lblMaterial")
+mouse_filter = 2
+theme = ExtResource("1")
+script = ExtResource("2")
+metadata/_edit_use_anchors_ = true
 
 [node name="Panel" type="Panel" parent="."]
-offset_left = 6.0
-offset_top = 4.0
-offset_right = 144.0
-offset_bottom = 180.0
+layout_mode = 2
 mouse_filter = 2
 
 [node name="Container" type="VBoxContainer" parent="."]
-offset_left = 6.0
-offset_top = 4.0
-offset_right = 144.0
-offset_bottom = 180.0
+layout_mode = 2
 
 [node name="Properties" type="VBoxContainer" parent="Container"]
-offset_right = 138.0
-offset_bottom = 29.0
+layout_mode = 2
 mouse_filter = 2
 
 [node name="IDX" type="Label" parent="Container/Properties"]
-offset_right = 138.0
-offset_bottom = 29.0
+unique_name_in_owner = true
+layout_mode = 2
 text = "IDX: [1,2]"
 
 [node name="Functions" type="VBoxContainer" parent="Container"]
-offset_top = 33.0
-offset_right = 138.0
-offset_bottom = 55.0
+layout_mode = 2
 mouse_filter = 2
 
 [node name="Make Inner Curve" type="Button" parent="Container/Functions"]
 visible = false
-offset_right = 140.0
-offset_bottom = 20.0
+layout_mode = 2
 text = "Make Inner Curve"
 
 [node name="Make Outer Curve" type="Button" parent="Container/Functions"]
 visible = false
-offset_top = 24.0
-offset_right = 140.0
-offset_bottom = 44.0
+layout_mode = 2
 text = "Make Outer Curve"
 
 [node name="MaterialOverride" type="Button" parent="Container/Functions"]
-offset_right = 138.0
-offset_bottom = 22.0
+unique_name_in_owner = true
+layout_mode = 2
 toggle_mode = true
 text = "Material Override"
 
-[node name="Override" type="VBoxContainer" parent="Container"]
-offset_top = 59.0
-offset_right = 138.0
-offset_bottom = 176.0
+[node name="OverrideContainer" type="VBoxContainer" parent="Container"]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
 
-[node name="HSeparator" type="HSeparator" parent="Container/Override"]
-offset_right = 138.0
-offset_bottom = 4.0
+[node name="HSeparator" type="HSeparator" parent="Container/OverrideContainer"]
+layout_mode = 2
 
-[node name="Render" type="CheckBox" parent="Container/Override"]
-offset_top = 8.0
-offset_right = 138.0
-offset_bottom = 32.0
-pressed = true
+[node name="Render" type="CheckBox" parent="Container/OverrideContainer"]
+unique_name_in_owner = true
+layout_mode = 2
 text = "Render"
 
-[node name="Weld" type="CheckBox" parent="Container/Override"]
+[node name="Weld" type="CheckBox" parent="Container/OverrideContainer"]
+unique_name_in_owner = true
 visible = false
-offset_top = 36.0
-offset_right = 130.0
-offset_bottom = 60.0
-pressed = true
+layout_mode = 2
 text = "Weld"
 
-[node name="Z_Index" type="HBoxContainer" parent="Container/Override"]
+[node name="ZIndexSection" type="HBoxContainer" parent="Container/OverrideContainer"]
 visible = false
-offset_top = 64.0
-offset_right = 130.0
-offset_bottom = 88.0
+layout_mode = 2
 
-[node name="lbl" type="Label" parent="Container/Override/Z_Index"]
-offset_right = 20.0
-offset_bottom = 24.0
+[node name="lbl" type="Label" parent="Container/OverrideContainer/ZIndexSection"]
+layout_mode = 2
 text = "Z:"
 
-[node name="Z_index" type="SpinBox" parent="Container/Override/Z_Index"]
-offset_left = 24.0
-offset_right = 98.0
-offset_bottom = 24.0
+[node name="ZIndex" type="SpinBox" parent="Container/OverrideContainer/ZIndexSection"]
+unique_name_in_owner = true
+layout_mode = 2
 min_value = -100.0
 
-[node name="SetMaterial" type="Button" parent="Container/Override"]
-offset_top = 36.0
-offset_right = 138.0
-offset_bottom = 58.0
+[node name="SetMaterial" type="Button" parent="Container/OverrideContainer"]
+unique_name_in_owner = true
+layout_mode = 2
 text = "Set Material"
 
-[node name="ClearMaterial" type="Button" parent="Container/Override"]
-offset_top = 62.0
-offset_right = 138.0
-offset_bottom = 84.0
+[node name="ClearMaterial" type="Button" parent="Container/OverrideContainer"]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
 text = "Clear Material"
 
-[node name="lblMaterial" type="Label" parent="Container/Override"]
-offset_top = 88.0
-offset_right = 138.0
-offset_bottom = 117.0
+[node name="MaterialStatus" type="Label" parent="Container/OverrideContainer"]
+unique_name_in_owner = true
+layout_mode = 2
 text = "[No Material]"

--- a/addons/rmsmartshape/scenes/GUI_InfoPanel.gd
+++ b/addons/rmsmartshape/scenes/GUI_InfoPanel.gd
@@ -1,19 +1,24 @@
 @tool
 extends PanelContainer
 
-@export (NodePath) var p_lbl_idx
-@export (NodePath) var p_lbl_tex
-@export (NodePath) var p_lbl_width
-@export (NodePath) var p_lbl_flip
 
-func set_idx(i:int):
-	get_node(p_lbl_idx).text = "IDX: %s" % i
+@onready var idx_label: Label = %IDX
+@onready var tex_label: Label = %Tex
+@onready var width_label: Label = %Width
+@onready var flip_label: Label = %Flip
 
-func set_texture_idx(i:int):
-	get_node(p_lbl_tex).text = "Texture2D: %s" % i
 
-func set_width(f:float):
-	get_node(p_lbl_width).text = "Width: %s" % f
+func set_idx(i: int) -> void:
+	idx_label.text = "IDX: %s" % i
 
-func set_flip(b:bool):
-	get_node(p_lbl_flip).text = "Flip: %s" % b
+
+func set_texture_idx(i: int) -> void:
+	tex_label.text = "Texture2D: %s" % i
+
+
+func set_width(f: float) -> void:
+	width_label.text = "Width: %s" % f
+
+
+func set_flip(b: bool) -> void:
+	flip_label.text = "Flip: %s" % b

--- a/addons/rmsmartshape/scenes/GUI_InfoPanel.tscn
+++ b/addons/rmsmartshape/scenes/GUI_InfoPanel.tscn
@@ -1,59 +1,44 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=3 format=3 uid="uid://cxu6258urdtf1"]
 
-[ext_resource path="res://addons/rmsmartshape/assets/GUI_Theme.tres" type="Theme" id=1]
-[ext_resource path="res://addons/rmsmartshape/scenes/GUI_InfoPanel.gd" type="Script" id=2]
+[ext_resource type="Theme" uid="uid://bdtg0tabufa3j" path="res://addons/rmsmartshape/assets/GUI_Theme.tres" id="1"]
+[ext_resource type="Script" path="res://addons/rmsmartshape/scenes/GUI_InfoPanel.gd" id="2"]
 
 [node name="GUI_InfoPanel" type="PanelContainer"]
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_right = -918.0
 offset_bottom = -486.0
-mouse_filter = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4
-theme = ExtResource( 1 )
-script = ExtResource( 2 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-p_lbl_idx = NodePath("Properties/IDX")
-p_lbl_tex = NodePath("Properties/Tex")
-p_lbl_width = NodePath("Properties/Width")
-p_lbl_flip = NodePath("Properties/Flip")
+mouse_filter = 2
+theme = ExtResource("1")
+script = ExtResource("2")
 
 [node name="Panel" type="Panel" parent="."]
-offset_left = 6.0
-offset_top = 4.0
-offset_right = 114.0
-offset_bottom = 132.0
+layout_mode = 2
 mouse_filter = 2
 
 [node name="Properties" type="VBoxContainer" parent="."]
-offset_left = 6.0
-offset_top = 4.0
-offset_right = 114.0
-offset_bottom = 132.0
+layout_mode = 2
 mouse_filter = 2
 
 [node name="IDX" type="Label" parent="Properties"]
-offset_right = 108.0
-offset_bottom = 29.0
+unique_name_in_owner = true
+layout_mode = 2
 text = "IDX: 13"
 
 [node name="Tex" type="Label" parent="Properties"]
-offset_top = 33.0
-offset_right = 108.0
-offset_bottom = 62.0
+unique_name_in_owner = true
+layout_mode = 2
 text = "Tex: 1"
 
 [node name="Width" type="Label" parent="Properties"]
-offset_top = 66.0
-offset_right = 108.0
-offset_bottom = 95.0
+unique_name_in_owner = true
+layout_mode = 2
 text = "Width: 1.0"
 
 [node name="Flip" type="Label" parent="Properties"]
-offset_top = 99.0
-offset_right = 108.0
-offset_bottom = 128.0
+unique_name_in_owner = true
+layout_mode = 2
 text = "Flip: N"

--- a/addons/rmsmartshape/shapes/shape_meta.gd
+++ b/addons/rmsmartshape/shapes/shape_meta.gd
@@ -14,57 +14,51 @@ var _cached_shape_children: Array = []
 #############
 # OVERRIDES #
 #############
-func _init():
+func _init() -> void:
 	super._init()
 	_is_instantiable = true
 
 
-func _ready():
+func _ready() -> void:
 	for s in _get_shapes(self):
 		_add_to_meta(s)
+	connect("child_entered_tree", self._on_child_entered_tree)
+	connect("child_exiting_tree", self._on_child_exiting_tree)
 	call_deferred("_update_cached_children")
 	super._ready()
 
 
-func _draw():
+func _draw() -> void:
 	pass
 
 
-func remove_child(node: Node):
-	_remove_from_meta(node)
+func _on_child_entered_tree(child: Node) -> void:
+	_add_to_meta(child)
 	call_deferred("_update_cached_children")
-	super.remove_child(node)
 
 
-func add_child(node: Node, force_readable_name: bool = false, internal: InternalMode = 0):
-	_add_to_meta(node)
+func _on_child_exiting_tree(child: Node) -> void:
+	_remove_from_meta(child)
 	call_deferred("_update_cached_children")
-	super.add_child(node, force_readable_name, internal)
 
 
-func add_sibling(sibling: Node, force_readable_name: bool = false):
-	_add_to_meta(sibling)
-	call_deferred("_update_cached_children")
-	super.add_sibling(sibling, force_readable_name)
-
-
-func _on_dirty_update():
+func _on_dirty_update() -> void:
 	pass
 
 
-func set_as_dirty():
+func set_as_dirty() -> void:
 	_update_shapes()
 
 ########
 # META #
 ########
-func _on_update_children(_ignore: bool):
+func _on_update_children(_ignore: bool) -> void:
 	#print("Updating Cached Children...")
 	_update_cached_children()
 	#print("...Updated")
 
 
-func _update_cached_children():
+func _update_cached_children() -> void:
 	# TODO, need to be made aware when cached children's children change!
 	_cached_shape_children = _get_shapes(self)
 	if treat_as_closed():
@@ -85,7 +79,7 @@ func _get_shapes(n: Node, a: Array = []) -> Array:
 	return a
 
 
-func _add_to_meta(n: Node):
+func _add_to_meta(n: Node) -> void:
 	if not n is SS2D_Shape_Base:
 		return
 	# Assign node to have the same point array data as this meta shape
@@ -93,7 +87,7 @@ func _add_to_meta(n: Node):
 	n.connect("points_modified",Callable(self,"_update_shapes").bind(n))
 
 
-func _update_shapes(except: Array = []):
+func _update_shapes(except: Array = []) -> void:
 	_update_curve(_points)
 	for s in _cached_shape_children:
 		if not except.has(s):
@@ -101,14 +95,15 @@ func _update_shapes(except: Array = []):
 			s._update_curve(s.get_point_array())
 
 
-func _remove_from_meta(n: Node):
+func _remove_from_meta(n: Node) -> void:
 	if not n is SS2D_Shape_Base:
 		return
 	# Make Point Data Unique
 	n.set_point_array(n.get_point_array(), true)
 	n.disconnect("points_modified",Callable(self,"_update_shapes"))
 
-func treat_as_closed()->bool:
+
+func treat_as_closed() -> bool:
 	var has_closed = false
 	for c in _cached_shape_children:
 		if c is SS2D_Shape_Closed:


### PR DESCRIPTION
I've marked some warnings to be ignored - particularly those that complain about overriding native class declaration. It seems intentional, since those methods are later used in other places of the plugin.